### PR TITLE
:bug: fix: resolve issue with long untagged image names

### DIFF
--- a/bin/gbox-box-list
+++ b/bin/gbox-box-list
@@ -131,7 +131,7 @@ main() {
                 # Only show header and data if there are results
                 echo "ID                                      IMAGE               STATUS"
                 echo "---------------------------------------- ------------------- ---------------"
-                echo "$response" | jq -r '.boxes[] | "\(.id) \(.image) \(.status)"' | column -t
+                echo "$response" | jq -r '.boxes[] | "\(.id) \(if (.image | startswith("sha256:")) then (.image | sub("^sha256:"; "") | if length > 12 then .[0:12] else . end) else .image end) \(.status)"' | column -t
             fi
             ;;
         "404")


### PR DESCRIPTION
before
```bash
❯ ./gbox box list
ID                                      IMAGE               STATUS
---------------------------------------- ------------------- ---------------
9e908a6b-8aac-4433-b28c-cb386f4a379e  babelcloud/gbox-python:latest                                            stopped
033da13c-4238-4c63-81be-db8da8a8ff41  sha256:6f2c3f86c4b9f983fdf8d521496a74159aa262bad7a624a21720b9f175efb0e3  stopped
6989377f-ab37-469e-88d3-3c7f94f33e68  ubuntu:latest                                                            stopped
```        

after
```bash
❯ ./gbox box list
ID                                      IMAGE               STATUS
---------------------------------------- ------------------- ---------------
9e908a6b-8aac-4433-b28c-cb386f4a379e  babelcloud/gbox-python:latest  stopped
033da13c-4238-4c63-81be-db8da8a8ff41  6f2c3f86c4b9                   stopped
6989377f-ab37-469e-88d3-3c7f94f33e68  ubuntu:latest                  stopped        
```                               

