### PR TITLE
:bug: fix: Box list '-f' arg is not effective

### DIFF
--- a/packages/api-server/handlers/docker/list.go
+++ b/packages/api-server/handlers/docker/list.go
@@ -19,15 +19,12 @@ func handleListBoxes(h *DockerBoxHandler, req *restful.Request, resp *restful.Re
 
 	// Build Docker filter args
 	filterArgs := filters.NewArgs()
-	// Add base filter for gbox containers
-	filterArgs.Add("label", GboxLabelName)
-	logger.Debug("Initialized filter args with base filter: %v", filterArgs)
 
 	// Get filters from query parameters
-	filters := req.QueryParameters("filter")
-	logger.Debug("Received query filters: %v", filters)
+	queryFilters := req.QueryParameters("filter")
+	logger.Debug("Received query filters: %v", queryFilters)
 
-	for _, filter := range filters {
+	for _, filter := range queryFilters {
 		// Parse filter format: field=value
 		// For label filters, value might contain multiple equals signs
 		firstEquals := strings.Index(filter, "=")
@@ -72,7 +69,7 @@ func handleListBoxes(h *DockerBoxHandler, req *restful.Request, resp *restful.Re
 
 	// Get containers with filters
 	logger.Debug("Querying Docker with filters: %v", filterArgs)
-	containerList, err := h.getAllContainers(req.Request.Context())
+	containerList, err := h.getContainers(req.Request.Context(), &filterArgs)
 	if err != nil {
 		logger.Error("Failed to list containers: %v", err)
 		resp.WriteError(http.StatusInternalServerError, err)


### PR DESCRIPTION
- Rename getAllContainers to getContainers for filter support
- Merge additional filters into container listing logic
- Improve logging for filter initialization and merging
- Update handleListBoxes to use new getContainers method

resolves: https://github.com/babelcloud/gru-sandbox/issues/31

```bash
❯ ./gbox box list -f 'label=project=myapp1'
No boxes found
❯ ./gbox box list -f 'label=project=myapp'
ID                                      IMAGE               STATUS
---------------------------------------- ------------------- ---------------
istanbul-warsaw-1098  ubuntu:latest  running
```